### PR TITLE
Refine book search filter to exclude title

### DIFF
--- a/BestReads.Tests/Features/BookRecommendations/Services/BookSearchServiceTests.cs
+++ b/BestReads.Tests/Features/BookRecommendations/Services/BookSearchServiceTests.cs
@@ -38,7 +38,7 @@ public class BookSearchServiceTests
         result.Should().NotBeNull();
         result.Should().BeEquivalentTo(expectedRecommendations);
 
-        var expectedFilter = $"GoogleBooksId ne '{book.GoogleBooksId}'";
+        var expectedFilter = $"GoogleBooksId ne '{book.GoogleBooksId}' and Title ne '{book.Title}'";
         var expectedSelectOptions = new List<string>
         {
             "doc_id, GoogleBooksId, Title, Authors, Categories, Description, Publisher, PublishedDate, Thumbnail, IndustryIdentifiers"

--- a/BestReads/Features/BookRecommendations/Services/BookSearchService/BookSearchService.cs
+++ b/BestReads/Features/BookRecommendations/Services/BookSearchService/BookSearchService.cs
@@ -15,7 +15,7 @@ public class BookSearchService : IBookSearchService
 
     public async Task<List<BookRecommendationDto>> GetNearestNeighbors(Book book)
     {
-        var filter = $"GoogleBooksId ne \'{book.GoogleBooksId}\'";
+        var filter = $"GoogleBooksId ne '{book.GoogleBooksId}' and Title ne '{book.Title}'";
         return await _azureSearchClient.SingleVectorSearch<BookRecommendationDto>(book.Embeddings,
             "Embeddings", filter,
             new List<string>


### PR DESCRIPTION
Extended the filter in the BookSearchService to not only exclude the GoogleBooksId, but also the Title of the specific book. This change refines the book recommendation functionality by ensuring the same book is not recommended twice based on different data fields (e.g. id versus title). The corresponding test cases have been updated to reflect this change.