### PR TITLE
Refactor to use Primary Constructors and remove ILogger from BookReco…

### DIFF
--- a/BestReads.Tests/Features/BookRecommendations/Controllers/BookRecommendationsControllerTests.cs
+++ b/BestReads.Tests/Features/BookRecommendations/Controllers/BookRecommendationsControllerTests.cs
@@ -4,7 +4,6 @@ using BestReads.Features.BookRecommendations.Errors;
 using BestReads.Features.BookRecommendations.Services.BookRecommendationService;
 using BestReads.Tests.Fakers;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using static BestReads.Tests.ControllerTestHelper;
 
 namespace BestReads.Tests.Features.BookRecommendations.Controllers;
@@ -12,15 +11,13 @@ namespace BestReads.Tests.Features.BookRecommendations.Controllers;
 public class BookRecommendationsControllerTests
 {
     private readonly BookRecommendationsController _controller;
-    private readonly Mock<ILogger<BookRecommendationsController>> _mockLogger;
     private readonly Mock<IBookRecommendationService> _mockService;
 
 
     public BookRecommendationsControllerTests()
     {
         _mockService = new Mock<IBookRecommendationService>();
-        _mockLogger = new Mock<ILogger<BookRecommendationsController>>();
-        _controller = new BookRecommendationsController(_mockService.Object, _mockLogger.Object);
+        _controller = new BookRecommendationsController(_mockService.Object);
     }
 
     [Fact]

--- a/BestReads/ADR/2. Primary Constructors Usage (.net 8).md
+++ b/BestReads/ADR/2. Primary Constructors Usage (.net 8).md
@@ -1,0 +1,58 @@
+﻿# Using Primary Constructors in .NET 8
+
+Primary constructors offer a compact approach for introducing dependencies into a class.
+
+**Before:**
+
+```csharp
+[ApiController]
+[Route("api/extensions/[controller]")]
+public class BookRecommendationsController : ControllerBase
+{
+    private readonly IBookRecommendationService _bookRecommendationService;
+
+    public BookRecommendationsController(IBookRecommendationService bookRecommendationService)
+    {
+        _bookRecommendationService = bookRecommendationService;
+    }
+}
+```
+
+**After:**
+
+```csharp
+[ApiController]
+[Route("api/extensions/[controller]")]
+public class BookRecommendationsController(IBookRecommendationService bookRecommendationService) : ControllerBase
+{
+    // Controller implementation
+}
+```
+
+While this approach is compact and elegant, it is important to realize that the constructor parameters are mutable.
+
+**Alternative Approach Considered:**
+
+```csharp
+[ApiController]
+[Route("api/extensions/[controller]")]
+public class BookRecommendationsController(IBookRecommendationService bookRecommendationService) : ControllerBase
+{
+    private readonly IBookRecommendationService bookRecommendationService = bookRecommendationService;
+}
+```
+
+This alternative approach addresses the issue of mutability but results in warnings due to the violation of the
+convention (the common convention is to prefix private instance fields with an underscore (_)). We could add
+a `GlobalSuppressions.cs` file to suppress warnings related to this. However, I decided not to adopt this approach as
+the IDE shortcuts still initialize the field with an underscore when initializing fields in this manner, requiring
+manual removal of these underscores.
+
+Given that this project is unit tested, we can be assured that any unintentional mutations should be caught by the
+tests. Therefore, I have made the decision to use primary constructors under the following conditions:
+
+- Use primary constructors if the class is unit tested.
+- For **infrastructure classes**, stick to readonly properties until we have integration tests in place.
+
+
+

--- a/BestReads/Features/BookRecommendations/Controllers/BookRecommendationsController.cs
+++ b/BestReads/Features/BookRecommendations/Controllers/BookRecommendationsController.cs
@@ -7,26 +7,15 @@ namespace BestReads.Features.BookRecommendations.Controllers;
 
 [ApiController]
 [Route("api/extensions/[controller]")]
-public class BookRecommendationsController : ControllerBase
+public class BookRecommendationsController(
+    IBookRecommendationService bookRecommendationService)
+    : ControllerBase
 {
-    private readonly IBookRecommendationService _bookRecommendationService;
-    private readonly ILogger<BookRecommendationsController> _logger;
-
-
-    public BookRecommendationsController(IBookRecommendationService bookRecommendationService,
-        ILogger<BookRecommendationsController> logger)
-    {
-        _bookRecommendationService = bookRecommendationService;
-        _logger = logger;
-    }
-
     [HttpPost]
     public async Task<ActionResult<ServiceResponse<List<BookRecommendationDto>>>> GenerateBookRecommendations(
         GetBookRecommendationsDto bookRecommendationsDto)
     {
-        _logger.LogInformation($"Request received for GenerateBookRecommendations: {bookRecommendationsDto.Title}");
-
-        var serviceResponse = (await _bookRecommendationService.GenerateRecommendations(bookRecommendationsDto))
+        var serviceResponse = (await bookRecommendationService.GenerateRecommendations(bookRecommendationsDto))
             .Match(
                 ServiceResponse<List<BookRecommendationDto>>.Success,
                 ServiceResponse<List<BookRecommendationDto>>.Failure

--- a/BestReads/Features/BookRecommendations/Repository/BookRepository/BookRepository.cs
+++ b/BestReads/Features/BookRecommendations/Repository/BookRepository/BookRepository.cs
@@ -4,14 +4,9 @@ using MongoDB.Driver;
 
 namespace BestReads.Features.BookRecommendations.Repository;
 
-public class BookRepository : IBookRepository
+public class BookRepository(MongoDbContext mongoDbContext) : IBookRepository
 {
-    private readonly IMongoCollection<Book> _books;
-
-    public BookRepository(MongoDbContext mongoDbContext)
-    {
-        _books = mongoDbContext.Books;
-    }
+    private readonly IMongoCollection<Book> _books = mongoDbContext.Books;
 
     public Task<Book?> GetByGoogleBooksIdAsync(string googleBooksId)
     {

--- a/BestReads/Features/BookRecommendations/Services/BookEmbeddingService/BookEmbeddingService.cs
+++ b/BestReads/Features/BookRecommendations/Services/BookEmbeddingService/BookEmbeddingService.cs
@@ -5,19 +5,11 @@ using BestReads.Features.BookRecommendations.Errors;
 
 namespace BestReads.Features.BookRecommendations.Services.BookEmbeddingService;
 
-public class BookEmbeddingService : IBookEmbeddingService
+public class BookEmbeddingService(IOpenAICleint openAiClient) : IBookEmbeddingService
 {
-    private readonly IOpenAICleint _openAiCleint;
-
-    public BookEmbeddingService(IOpenAICleint openAiCleint)
-    {
-        _openAiCleint = openAiCleint;
-    }
-
-
     public async Task<IReadOnlyList<float>> GetEmbeddingsFromOpenAI(EmbeddingRequest request)
     {
-        return await _openAiCleint.GetEmbeddingsAsync(request);
+        return await openAiClient.GetEmbeddingsAsync(request);
     }
 
     public Result<EmbeddingRequest> ConstructEmbeddingRequest(GetBookRecommendationsDto bookRecommendationsDto)


### PR DESCRIPTION
🎯 Main theme:
Refactoring to use primary constructors in .NET 8
🏷️ PR labels: Refactoring
📝 PR summary:
This PR refactors the code to use primary constructors in .NET 8, which provides a more compact way of introducing dependencies into a class. It also includes the removal of ILogger from BookRecommendationsControllerTests. An ADR (Architectural Decision Record) is added to document the decision of using primary constructors.
🧪 Relevant tests added: False
⏱️ Estimated effort to review [1-5]:
2 The PR is relatively straightforward, focusing on refactoring to use primary constructors. The changes are consistent across multiple files, which simplifies the review process.

PR Feedback
 
💡 General suggestions:
The refactoring looks clean and consistent across the codebase. The use of primary constructors simplifies the code and makes it more readable. However, it would be beneficial to ensure that all potential side effects of this change are considered and tested. For instance, the mutability of constructor parameters, as mentioned in the ADR, could potentially lead to issues if not handled carefully.
🔒 Security concerns: False
🏅 PR Score:
90 The PR is well-structured, and the changes are consistent and clean. The addition of an ADR is a good practice to document important decisions. However, the lack of new tests to cover the changes slightly reduces the score.